### PR TITLE
Email None fix

### DIFF
--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi_sqlalchemy import db
 
 from auth_backend.models.db import AuthMethod, Group, User, UserGroup, UserSession
+from auth_backend.schemas.models import User as UserModel
 from auth_backend.schemas.models import (
     UserAuthMethods,
     UserGet,
@@ -86,7 +87,7 @@ async def get_users(
     return UsersGet(**result).dict(exclude_unset=True, exclude={"session_scopes"})
 
 
-@user.patch("/{user_id}", response_model=UserInfo, response_model_exclude={"email"})
+@user.patch("/{user_id}", response_model=UserModel)
 async def patch_user(
     user_id: int,
     user_inp: UserPatch,
@@ -113,7 +114,7 @@ async def patch_user(
         )
         UserGroup.delete(user_group.id, session=db.session)
     db.session.commit()
-    return UserInfo.from_orm(user)
+    return UserModel.from_orm(user)
 
 
 @user.delete("/{user_id}", response_model=None)

--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -86,7 +86,7 @@ async def get_users(
     return UsersGet(**result).dict(exclude_unset=True, exclude={"session_scopes"})
 
 
-@user.patch("/{user_id}", response_model=UserInfo, response_model_exclude_none=True)
+@user.patch("/{user_id}", response_model=UserInfo, response_model_exclude={"email"})
 async def patch_user(
     user_id: int,
     user_inp: UserPatch,

--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -113,7 +113,11 @@ async def patch_user(
         )
         UserGroup.delete(user_group.id, session=db.session)
     db.session.commit()
-    return UserInfo.from_orm(user)
+    res = {
+        "id": user.id,
+        "email": user.auth_methods.email.email.value if user.auth_methods.email.email else None,
+    }
+    return UserInfo(**res)
 
 
 @user.delete("/{user_id}", response_model=None)

--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -86,7 +86,7 @@ async def get_users(
     return UsersGet(**result).dict(exclude_unset=True, exclude={"session_scopes"})
 
 
-@user.patch("/{user_id}", response_model=UserInfo)
+@user.patch("/{user_id}", response_model=UserInfo, response_model_exclude_none=True)
 async def patch_user(
     user_id: int,
     user_inp: UserPatch,
@@ -113,11 +113,7 @@ async def patch_user(
         )
         UserGroup.delete(user_group.id, session=db.session)
     db.session.commit()
-    res = {
-        "id": user.id,
-        "email": user.auth_methods.email.email.value if user.auth_methods.email.email else None,
-    }
-    return UserInfo(**res)
+    return UserInfo.from_orm(user)
 
 
 @user.delete("/{user_id}", response_model=None)

--- a/auth_backend/schemas/models.py
+++ b/auth_backend/schemas/models.py
@@ -39,8 +39,11 @@ class GroupGet(Group, GroupChilds, GroupIndirectScopes, GroupScopes, GroupUserLi
     pass
 
 
-class UserInfo(Base):
+class User(Base):
     id: int
+
+
+class UserInfo(User):
     email: str | None
 
 

--- a/tests/test_routes/test_user.py
+++ b/tests/test_routes/test_user.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from auth_backend.models import AuthMethod, User
+from auth_backend.models.db import Group
+
+
+def test_user_email(client: TestClient, dbsession: Session, user_factory):
+    user1 = user_factory(client)
+    time1 = datetime.utcnow()
+    user: User = dbsession.query(User).get(user1)
+    body = {"name": f"group{time1}", "parent_id": None, "scopes": []}
+    group = client.post(url="/group", json=body).json()["id"]
+    email_user = AuthMethod(user_id=user1, param="email", auth_method="email", value="testemailx@x.xy")
+    dbsession.add(email_user)
+    dbsession.commit()
+    resp = client.patch(f"/user/{user1}", json={"groups": [group]})
+    assert resp.status_code == 200
+    assert resp.json()["email"] == user.auth_methods.email.email.value
+    dbsession.delete(email_user)
+    gr = Group.get(group, session=dbsession)
+    dbsession.delete(gr)
+    dbsession.commit()

--- a/tests/test_routes/test_user.py
+++ b/tests/test_routes/test_user.py
@@ -18,7 +18,7 @@ def test_user_email(client: TestClient, dbsession: Session, user_factory):
     dbsession.commit()
     resp = client.patch(f"/user/{user1}", json={"groups": [group]})
     assert resp.status_code == 200
-    assert resp.json()["email"] == user.auth_methods.email.email.value
+    assert "email" not in resp.json().keys()
     dbsession.delete(email_user)
     gr = Group.get(group, session=dbsession)
     dbsession.delete(gr)

--- a/tests/test_routes/test_user_groups.py
+++ b/tests/test_routes/test_user_groups.py
@@ -25,6 +25,8 @@ def test_add_user(client: TestClient, dbsession: Session, user_factory):
     user = User.get(usergroup.user_id, session=dbsession)
     assert user in gr.users
     assert gr in user.groups
+    dbsession.delete(gr)
+    dbsession.commit()
 
 
 def test_get_user_list(client, dbsession, user_factory):


### PR DESCRIPTION
## Изменения
Теперь ручка `PATCH /user/{id}` возвращает корректный email

## Реализации
Генерация корректного словаря в соответствующей ручке

## Детали
Раньше там был from_orm, а поля email в user нет, я сделал корректный словарь

## Check-List
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить black и isort?
