### PR TITLE
Prohibition to remove the last authentication method

### DIFF
--- a/auth_backend/auth_plugins/auth_method.py
+++ b/auth_backend/auth_plugins/auth_method.py
@@ -13,7 +13,7 @@ from pydantic import constr
 from sqlalchemy.orm import Session as DbSession
 
 from auth_backend.base import Base
-from auth_backend.exceptions import AlreadyExists
+from auth_backend.exceptions import AlreadyExists, LastAuthMethodDelete
 from auth_backend.models.db import AuthMethod, User, UserSession
 from auth_backend.schemas.types.scopes import Scope as TypeScope
 from auth_backend.settings import get_settings
@@ -312,6 +312,9 @@ class OauthMeta(AuthMethodMeta):
             )
             .all()
         )
+        all_auth_methods = AuthMethod.query(session=db_session).filter(AuthMethod.user_id == user.id).all()
+        if len(all_auth_methods) - len(auth_methods) == 0:
+            raise LastAuthMethodDelete()
         logger.debug(auth_methods)
         for method in auth_methods:
             method.is_deleted = True

--- a/auth_backend/auth_plugins/yandex.py
+++ b/auth_backend/auth_plugins/yandex.py
@@ -43,7 +43,7 @@ class YandexAuth(OauthMeta):
 
     class OauthResponseSchema(BaseModel):
         code: str | None = None
-        id_token: str | None = Field(help="Yandex JWT token identifier")
+        id_token: str | None = Field(default=None, help="Yandex JWT token identifier")
         scopes: list[Scope] | None = None
         session_name: str | None = None
 

--- a/auth_backend/exceptions.py
+++ b/auth_backend/exceptions.py
@@ -44,3 +44,8 @@ class TooManyEmailRequests(Exception):
     def __init__(self, dtime: datetime.timedelta):
         self.delay_time = dtime
         super().__init__(f'Delay: {dtime}')
+
+
+class LastAuthMethodDelete(Exception):
+    def __init__(self):
+        super().__init__(f'Unable to remove last authentication method')

--- a/auth_backend/routes/exc_handlers.py
+++ b/auth_backend/routes/exc_handlers.py
@@ -71,7 +71,7 @@ async def http_error_handler(req: starlette.requests.Request, exc: Exception):
 
 
 @app.exception_handler(TooManyEmailRequests)
-async def http_error_handler(req: starlette.requests.Request, exc: TooManyEmailRequests):
+async def too_many_requests_handler(req: starlette.requests.Request, exc: TooManyEmailRequests):
     return JSONResponse(
         content=StatusResponseModel(
             status="Error", message=f"Too many requests. Delay time: {int(exc.delay_time.total_seconds())} seconds."
@@ -81,7 +81,7 @@ async def http_error_handler(req: starlette.requests.Request, exc: TooManyEmailR
 
 
 @app.exception_handler(LastAuthMethodDelete)
-async def http_error_handler(req: starlette.requests.Request, exc: LastAuthMethodDelete):
+async def last_auth_method_delete_handler(req: starlette.requests.Request, exc: LastAuthMethodDelete):
     return JSONResponse(
         content=StatusResponseModel(status="Error", message=f"Unable to remove last authentication method").dict(),
         status_code=403,

--- a/auth_backend/routes/exc_handlers.py
+++ b/auth_backend/routes/exc_handlers.py
@@ -6,6 +6,7 @@ from auth_backend.exceptions import (
     AlreadyExists,
     AuthFailed,
     IncorrectUserAuthType,
+    LastAuthMethodDelete,
     OauthAuthFailed,
     OauthCredentialsIncorrect,
     ObjectNotFound,
@@ -76,4 +77,12 @@ async def http_error_handler(req: starlette.requests.Request, exc: TooManyEmailR
             status="Error", message=f"Too many requests. Delay time: {int(exc.delay_time.total_seconds())} seconds."
         ).dict(),
         status_code=429,
+    )
+
+
+@app.exception_handler(LastAuthMethodDelete)
+async def http_error_handler(req: starlette.requests.Request, exc: LastAuthMethodDelete):
+    return JSONResponse(
+        content=StatusResponseModel(status="Error", message=f"Unable to remove last authentication method").dict(),
+        status_code=403,
     )

--- a/cleanupdb.sh
+++ b/cleanupdb.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+alembic downgrade head-"$(alembic heads | wc -l | sed 's/ //g')"
+alembic upgrade head

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ retrying
 aiohttp
 logging-profcomff
 pydantic-settings
+pytest-asyncio
 
 # Google Auth Method
 google-api-python-client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,17 +227,10 @@ def yandex_user(dbsession) -> User:
         exit(errno.EIO)
     user = User.create(session=dbsession)
     dbsession.flush()
-    email = AuthMethod.create(
-        user_id=user.id, param="email", value=email, auth_method=YandexAuth.get_name(), session=dbsession
+    user_id = AuthMethod.create(
+        user_id=user.id, param="user_id", value=user.id, auth_method=YandexAuth.get_name(), session=dbsession
     )
-    _salt = random_string()
-    confirmed = AuthMethod.create(
-        user_id=user.id, param="confirmed", value="true", auth_method=YandexAuth.get_name(), session=dbsession
-    )
-    confirmation_token = AuthMethod.create(
-        user_id=user.id, param=random_string(), value="admin", auth_method=YandexAuth.get_name(), session=dbsession
-    )
-    dbsession.add_all([email, confirmed, confirmation_token])
+    dbsession.add(user_id)
     dbsession.commit()
     yield user
     dbsession.query(AuthMethod).filter(AuthMethod.user_id == user.id).delete()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,6 @@ def client_auth_email_delay():
 @pytest.fixture()
 def yandex_user(dbsession) -> User:
     email = f"{random_string()}@yandex.ru"
-    password = random_string()
     if (
         AuthMethod.query(session=dbsession)
         .filter(AuthMethod.value == email, AuthMethod.auth_method == YandexAuth.get_name())
@@ -232,23 +231,13 @@ def yandex_user(dbsession) -> User:
         user_id=user.id, param="email", value=email, auth_method=YandexAuth.get_name(), session=dbsession
     )
     _salt = random_string()
-    password = AuthMethod.create(
-        user_id=user.id,
-        param="hashed_password",
-        value=Email._hash_password(password, _salt),
-        auth_method=YandexAuth.get_name(),
-        session=dbsession,
-    )
-    salt = AuthMethod.create(
-        user_id=user.id, param="salt", value=_salt, auth_method=YandexAuth.get_name(), session=dbsession
-    )
     confirmed = AuthMethod.create(
         user_id=user.id, param="confirmed", value="true", auth_method=YandexAuth.get_name(), session=dbsession
     )
     confirmation_token = AuthMethod.create(
         user_id=user.id, param=random_string(), value="admin", auth_method=YandexAuth.get_name(), session=dbsession
     )
-    dbsession.add_all([email, password, salt, confirmed, confirmation_token])
+    dbsession.add_all([email, confirmed, confirmation_token])
     dbsession.commit()
     yield user
     dbsession.query(AuthMethod).filter(AuthMethod.user_id == user.id).delete()

--- a/tests/test_routes/test_delete_last_auth_method.py
+++ b/tests/test_routes/test_delete_last_auth_method.py
@@ -1,0 +1,62 @@
+import asyncio
+import errno
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from auth_backend.auth_plugins import YandexAuth
+from auth_backend.auth_plugins.auth_method import random_string
+from auth_backend.exceptions import LastAuthMethodDelete
+from auth_backend.models import AuthMethod, User
+from auth_backend.settings import Settings, get_settings
+
+
+pytest_plugins = ('pytest_asyncio',)
+
+settings = get_settings()
+
+
+def create_test_user(email: str, password: str, dbsession) -> User:
+    if (
+        AuthMethod.query(session=dbsession)
+        .filter(AuthMethod.value == email, AuthMethod.auth_method == YandexAuth.get_name())
+        .one_or_none()
+    ):
+        exit(errno.EIO)
+    user = User.create(session=dbsession)
+    dbsession.flush()
+    email = AuthMethod.create(
+        user_id=user.id, param="email", value=email, auth_method=YandexAuth.get_name(), session=dbsession
+    )
+    _salt = random_string()
+    password = AuthMethod.create(
+        user_id=user.id,
+        param="hashed_password",
+        value="///",
+        auth_method=YandexAuth.get_name(),
+        session=dbsession,
+    )
+    salt = AuthMethod.create(
+        user_id=user.id, param="salt", value=_salt, auth_method=YandexAuth.get_name(), session=dbsession
+    )
+    confirmed = AuthMethod.create(
+        user_id=user.id, param="confirmed", value="true", auth_method=YandexAuth.get_name(), session=dbsession
+    )
+    confirmation_token = AuthMethod.create(
+        user_id=user.id, param="confirmation_token", value="admin", auth_method=YandexAuth.get_name(), session=dbsession
+    )
+    dbsession.add_all([email, password, salt, confirmed, confirmation_token])
+    dbsession.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_delete_method(dbsession):
+    user = create_test_user("em@yandex.ru", "12345678", dbsession)
+    with pytest.raises(LastAuthMethodDelete):
+        await YandexAuth._delete_auth_methods(user, db_session=dbsession)
+    dbsession.query(AuthMethod).filter(AuthMethod.user_id == user.id).delete()
+    dbsession.query(User).filter(User.id == user.id).delete()
+    dbsession.commit()

--- a/tests/test_routes/test_delete_last_auth_method.py
+++ b/tests/test_routes/test_delete_last_auth_method.py
@@ -1,12 +1,14 @@
 import asyncio
 import errno
+import random
+import string
 
 import pytest
 import pytest_asyncio
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from auth_backend.auth_plugins import YandexAuth
+from auth_backend.auth_plugins import Email, YandexAuth
 from auth_backend.auth_plugins.auth_method import random_string
 from auth_backend.exceptions import LastAuthMethodDelete
 from auth_backend.models import AuthMethod, User
@@ -18,45 +20,7 @@ pytest_plugins = ('pytest_asyncio',)
 settings = get_settings()
 
 
-def create_test_user(email: str, password: str, dbsession) -> User:
-    if (
-        AuthMethod.query(session=dbsession)
-        .filter(AuthMethod.value == email, AuthMethod.auth_method == YandexAuth.get_name())
-        .one_or_none()
-    ):
-        exit(errno.EIO)
-    user = User.create(session=dbsession)
-    dbsession.flush()
-    email = AuthMethod.create(
-        user_id=user.id, param="email", value=email, auth_method=YandexAuth.get_name(), session=dbsession
-    )
-    _salt = random_string()
-    password = AuthMethod.create(
-        user_id=user.id,
-        param="hashed_password",
-        value="///",
-        auth_method=YandexAuth.get_name(),
-        session=dbsession,
-    )
-    salt = AuthMethod.create(
-        user_id=user.id, param="salt", value=_salt, auth_method=YandexAuth.get_name(), session=dbsession
-    )
-    confirmed = AuthMethod.create(
-        user_id=user.id, param="confirmed", value="true", auth_method=YandexAuth.get_name(), session=dbsession
-    )
-    confirmation_token = AuthMethod.create(
-        user_id=user.id, param="confirmation_token", value="admin", auth_method=YandexAuth.get_name(), session=dbsession
-    )
-    dbsession.add_all([email, password, salt, confirmed, confirmation_token])
-    dbsession.commit()
-    return user
-
-
 @pytest.mark.asyncio
-async def test_delete_method(dbsession):
-    user = create_test_user("em@yandex.ru", "12345678", dbsession)
+async def test_delete_method(yandex_user, dbsession):
     with pytest.raises(LastAuthMethodDelete):
-        await YandexAuth._delete_auth_methods(user, db_session=dbsession)
-    dbsession.query(AuthMethod).filter(AuthMethod.user_id == user.id).delete()
-    dbsession.query(User).filter(User.id == user.id).delete()
-    dbsession.commit()
+        await YandexAuth._delete_auth_methods(yandex_user, db_session=dbsession)


### PR DESCRIPTION
## Изменения
Предотвращена возможность удалить последний метод аутентификации.

## Реализации
Добавлена проверка на наличие других методов аутентификации при попытке пользователем удалить исходный метод.

## Детали
Происходит подсчет записей в базе данных, затем сравнивается число записей со всевозможными методами аутентификации и исходного метода. Если разность между количествами равна 0, то прокидывается 403 ошибка.

## Check-List
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить black и isort?
