### PR TITLE
Dynamic options and auto assign users/scopes to groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ format:
 	source ./venv/bin/activate && autoflake -r --in-place --remove-all-unused-imports ./auth_backend
 	source ./venv/bin/activate && isort ./auth_backend
 	source ./venv/bin/activate && black ./auth_backend
+	source ./venv/bin/activate && autoflake -r --in-place --remove-all-unused-imports ./tests
+	source ./venv/bin/activate && isort ./tests
+	source ./venv/bin/activate && black ./tests
+	source ./venv/bin/activate && autoflake -r --in-place --remove-all-unused-imports ./migrations
+	source ./venv/bin/activate && isort ./migrations
+	source ./venv/bin/activate && black ./migrations
 
 db:
 	docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name db-auth_api postgres:15

--- a/auth_backend/models/__init__.py
+++ b/auth_backend/models/__init__.py
@@ -1,5 +1,6 @@
 from .base import Base
 from .db import AuthMethod, User, UserSession
+from .dynamic_settings import DynamicOption
 
 
-__all__ = ["Base", "User", "UserSession", "AuthMethod"]
+__all__ = ["Base", "User", "UserSession", "AuthMethod", "DynamicOption"]

--- a/auth_backend/models/db.py
+++ b/auth_backend/models/db.py
@@ -42,20 +42,6 @@ class User(BaseDbModel):
         secondaryjoin="and_(Group.id==UserGroup.group_id, not_(Group.is_deleted))",
     )
 
-    @classmethod
-    def create(cls, *, session: Session, **kwargs) -> User:
-        user = super().create(session=session, **kwargs)
-        try:
-            users_group_id = DynamicOption.get("users_group_id", session=session)
-            group = session.get(Group, users_group_id.value)
-            if group:
-                group.users.append(user)
-            else:
-                logger.info(f"Can't to add user {user.id=} to group users {users_group_id.value=}")
-        except Exception:
-            logger.error("Failed to add user to users group", exc_info=True)
-        return user
-
     @hybrid_property
     def scopes(self) -> set[Scope]:
         _scopes = set()
@@ -224,20 +210,6 @@ class Scope(BaseDbModel):
         primaryjoin="and_(Scope.id==UserSessionScope.scope_id, not_(UserSessionScope.is_deleted))",
         secondaryjoin="(UserSession.id==UserSessionScope.user_session_id)",
     )
-
-    @classmethod
-    def create(cls, *, session: Session, **kwargs) -> User:
-        scope = super().create(session=session, **kwargs)
-        try:
-            root_group_id = DynamicOption.get("root_group_id", session=session)
-            group = session.get(Group, root_group_id.value)
-            if group:
-                group.scopes.add(scope)
-            else:
-                logger.info(f"Can't to add scope {scope.id=} to group users {root_group_id.id=}")
-        except Exception:
-            logger.error("Failed to add scope to root group", exc_info=True)
-        return scope
 
     @classmethod
     def get_by_name(cls, name: str, *, with_deleted: bool = False, session: Session) -> Scope:

--- a/auth_backend/models/db.py
+++ b/auth_backend/models/db.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 import datetime
+import logging
 from typing import Iterator
 
 import sqlalchemy.orm
@@ -10,9 +10,9 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, Session, backref, mapped_column, relationship
 
 from auth_backend.exceptions import ObjectNotFound
+from auth_backend.models.base import BaseDbModel
 from auth_backend.models.dynamic_settings import DynamicOption
 from auth_backend.settings import get_settings
-from auth_backend.models.base import BaseDbModel
 
 
 settings = get_settings()

--- a/auth_backend/models/db.py
+++ b/auth_backend/models/db.py
@@ -21,9 +21,9 @@ from auth_backend.models.base import BaseDbModel
 class User(BaseDbModel):
     __auth_methods_cached = None
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
     update_ts: Mapped[datetime.datetime] = mapped_column(
-        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        DateTime, default=datetime.datetime.now(datetime.UTC), onupdate=datetime.datetime.now(datetime.UTC)
     )
     _auth_methods: Mapped[list[AuthMethod]] = relationship(
         "AuthMethod",
@@ -92,9 +92,9 @@ class Group(BaseDbModel):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=False, nullable=False)
     parent_id: Mapped[int] = mapped_column(Integer, ForeignKey("group.id"), nullable=True)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
     update_ts: Mapped[datetime.datetime] = mapped_column(
-        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        DateTime, default=datetime.datetime.now(datetime.UTC), onupdate=datetime.datetime.now(datetime.UTC)
     )
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
@@ -146,9 +146,9 @@ class AuthMethod(BaseDbModel):
     auth_method: Mapped[str] = mapped_column(String)
     param: Mapped[str] = mapped_column(String)
     value: Mapped[str] = mapped_column(String, nullable=False)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
     update_ts: Mapped[datetime.datetime] = mapped_column(
-        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        DateTime, default=datetime.datetime.now(datetime.UTC), onupdate=datetime.datetime.now(datetime.UTC)
     )
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
@@ -161,7 +161,7 @@ class AuthMethod(BaseDbModel):
 
 
 def session_expires_date():
-    return datetime.datetime.utcnow() + datetime.timedelta(days=settings.SESSION_TIME_IN_DAYS)
+    return datetime.datetime.now(datetime.UTC)() + datetime.timedelta(days=settings.SESSION_TIME_IN_DAYS)
 
 
 class UserSession(BaseDbModel):
@@ -169,8 +169,8 @@ class UserSession(BaseDbModel):
     user_id: Mapped[int] = mapped_column(Integer, sqlalchemy.ForeignKey("user.id"))
     expires: Mapped[datetime.datetime] = mapped_column(DateTime, default=session_expires_date)
     token: Mapped[str] = mapped_column(String, unique=True)
-    last_activity: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    last_activity: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
     user: Mapped[User] = relationship(
         "User",
         foreign_keys=[user_id],
@@ -187,7 +187,7 @@ class UserSession(BaseDbModel):
 
     @hybrid_property
     def expired(self) -> bool:
-        return self.expires <= datetime.datetime.utcnow()
+        return self.expires <= datetime.datetime.now(datetime.UTC)()
 
 
 class Scope(BaseDbModel):
@@ -235,6 +235,6 @@ class UserSessionScope(BaseDbModel):
 
 
 class UserMessageDelay(BaseDbModel):
-    delay_time: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    delay_time: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
     user_email: Mapped[str] = mapped_column(String, unique=False)
     user_ip: Mapped[str] = mapped_column(String, unique=False)

--- a/auth_backend/models/db.py
+++ b/auth_backend/models/db.py
@@ -22,9 +22,9 @@ logger = logging.getLogger(__name__)
 class User(BaseDbModel):
     __auth_methods_cached = None
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
     update_ts: Mapped[datetime.datetime] = mapped_column(
-        DateTime, default=datetime.datetime.now(datetime.UTC), onupdate=datetime.datetime.now(datetime.UTC)
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
     _auth_methods: Mapped[list[AuthMethod]] = relationship(
         "AuthMethod",
@@ -107,9 +107,9 @@ class Group(BaseDbModel):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=False, nullable=False)
     parent_id: Mapped[int] = mapped_column(Integer, ForeignKey("group.id"), nullable=True)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
     update_ts: Mapped[datetime.datetime] = mapped_column(
-        DateTime, default=datetime.datetime.now(datetime.UTC), onupdate=datetime.datetime.now(datetime.UTC)
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
@@ -161,9 +161,9 @@ class AuthMethod(BaseDbModel):
     auth_method: Mapped[str] = mapped_column(String)
     param: Mapped[str] = mapped_column(String)
     value: Mapped[str] = mapped_column(String, nullable=False)
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
     update_ts: Mapped[datetime.datetime] = mapped_column(
-        DateTime, default=datetime.datetime.now(datetime.UTC), onupdate=datetime.datetime.now(datetime.UTC)
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
@@ -176,7 +176,7 @@ class AuthMethod(BaseDbModel):
 
 
 def session_expires_date():
-    return datetime.datetime.now(datetime.UTC)() + datetime.timedelta(days=settings.SESSION_TIME_IN_DAYS)
+    return datetime.datetime.utcnow() + datetime.timedelta(days=settings.SESSION_TIME_IN_DAYS)
 
 
 class UserSession(BaseDbModel):
@@ -184,8 +184,8 @@ class UserSession(BaseDbModel):
     user_id: Mapped[int] = mapped_column(Integer, sqlalchemy.ForeignKey("user.id"))
     expires: Mapped[datetime.datetime] = mapped_column(DateTime, default=session_expires_date)
     token: Mapped[str] = mapped_column(String, unique=True)
-    last_activity: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
-    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
+    last_activity: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    create_ts: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
     user: Mapped[User] = relationship(
         "User",
         foreign_keys=[user_id],
@@ -202,7 +202,7 @@ class UserSession(BaseDbModel):
 
     @hybrid_property
     def expired(self) -> bool:
-        return self.expires <= datetime.datetime.now(datetime.UTC)()
+        return self.expires <= datetime.datetime.utcnow()
 
 
 class Scope(BaseDbModel):
@@ -264,6 +264,6 @@ class UserSessionScope(BaseDbModel):
 
 
 class UserMessageDelay(BaseDbModel):
-    delay_time: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.now(datetime.UTC))
+    delay_time: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
     user_email: Mapped[str] = mapped_column(String, unique=False)
     user_ip: Mapped[str] = mapped_column(String, unique=False)

--- a/auth_backend/models/db.py
+++ b/auth_backend/models/db.py
@@ -42,6 +42,11 @@ class User(BaseDbModel):
         secondaryjoin="and_(Group.id==UserGroup.group_id, not_(Group.is_deleted))",
     )
 
+    @classmethod
+    def create(cls, *, session: Session, **kwargs) -> User:
+        user = super().create(session=session, **kwargs)
+        return user
+
     @hybrid_property
     def scopes(self) -> set[Scope]:
         _scopes = set()
@@ -210,6 +215,11 @@ class Scope(BaseDbModel):
         primaryjoin="and_(Scope.id==UserSessionScope.scope_id, not_(UserSessionScope.is_deleted))",
         secondaryjoin="(UserSession.id==UserSessionScope.user_session_id)",
     )
+
+    @classmethod
+    def create(cls, *, session: Session, **kwargs) -> Scope:
+        scope = super().create(session=session, **kwargs)
+        return scope
 
     @classmethod
     def get_by_name(cls, name: str, *, with_deleted: bool = False, session: Session) -> Scope:

--- a/auth_backend/models/dynamic_settings.py
+++ b/auth_backend/models/dynamic_settings.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 
 from sqlalchemy import DateTime, Double, Integer, String
 from sqlalchemy.orm import Mapped, Session, mapped_column

--- a/auth_backend/models/dynamic_settings.py
+++ b/auth_backend/models/dynamic_settings.py
@@ -12,8 +12,8 @@ class DynamicOption(Base):
     value_integer: Mapped[int] = mapped_column(Integer, nullable=True)
     value_double: Mapped[float] = mapped_column(Double, nullable=True)
     value_string: Mapped[str] = mapped_column(String, nullable=True)
-    create_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(UTC))
-    update_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(UTC), onupdate=datetime.now(UTC))
+    create_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    update_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     @property
     def value(self) -> str | float | int:

--- a/auth_backend/models/dynamic_settings.py
+++ b/auth_backend/models/dynamic_settings.py
@@ -1,0 +1,35 @@
+from datetime import datetime, UTC
+
+from sqlalchemy import DateTime, String, Integer, Double
+from sqlalchemy.orm import Mapped, mapped_column, Session
+
+from .base import Base
+
+
+class DynamicOption(Base):
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String, unique=True)
+    value_integer: Mapped[int] = mapped_column(Integer, nullable=True)
+    value_double: Mapped[float] = mapped_column(Double, nullable=True)
+    value_string: Mapped[str] = mapped_column(String, nullable=True)
+    create_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(UTC))
+    update_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(UTC), onupdate=datetime.now(UTC))
+
+    @property
+    def value(self) -> str | float | int:
+        return self.value_double or self.value_integer or self.value_string
+
+    @value.setter
+    def set_value(self, value: str | float | int):
+        if isinstance(value, str):
+            self.value_string = value
+        elif isinstance(value, float):
+            self.value_double = value
+        elif isinstance(value, int):
+            self.value_integer = value
+        else:
+            raise TypeError("Only str, float or int options allowed")
+
+    @staticmethod
+    def get(name, default=None, *, session: Session):
+        return session.query(DynamicOption).filter(DynamicOption.name == name).one_or_none() or default

--- a/auth_backend/models/dynamic_settings.py
+++ b/auth_backend/models/dynamic_settings.py
@@ -1,7 +1,7 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, String, Integer, Double
-from sqlalchemy.orm import Mapped, mapped_column, Session
+from sqlalchemy import DateTime, Double, Integer, String
+from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from .base import Base
 

--- a/auth_backend/routes/user_session.py
+++ b/auth_backend/routes/user_session.py
@@ -9,7 +9,7 @@ from starlette.responses import JSONResponse
 
 from auth_backend.base import StatusResponseModel
 from auth_backend.exceptions import ObjectNotFound, SessionExpired
-from auth_backend.models.db import AuthMethod, UserSession
+from auth_backend.models.db import AuthMethod, UserSession, session_expires_date
 from auth_backend.schemas.models import (
     Session,
     SessionPatch,
@@ -51,6 +51,7 @@ async def me(
         default=[]
     ),
 ) -> dict[str, str | int]:
+    session.expires = session_expires_date()  # Автопродление сессии при активности пользователя
     result: dict[str, str | int] = {}
     result = (
         result

--- a/migrations/versions/7c1cd7ceacd8_dynamic_option_model.py
+++ b/migrations/versions/7c1cd7ceacd8_dynamic_option_model.py
@@ -6,9 +6,10 @@ Create Date: 2024-04-05 22:36:58.224670
 
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.orm import Session
+
 from auth_backend.models.db import Group
 
 

--- a/migrations/versions/7c1cd7ceacd8_dynamic_option_model.py
+++ b/migrations/versions/7c1cd7ceacd8_dynamic_option_model.py
@@ -1,0 +1,70 @@
+"""Dynamic option model
+
+Revision ID: 7c1cd7ceacd8
+Revises: bda218c91211
+Create Date: 2024-04-05 22:36:58.224670
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from auth_backend.models.db import Group
+
+
+# revision identifiers, used by Alembic.
+revision = '7c1cd7ceacd8'
+down_revision = 'bda218c91211'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    dynamic_option_table = op.create_table(
+        'dynamic_option',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+        sa.Column('value_integer', sa.Integer(), nullable=True),
+        sa.Column('value_double', sa.Double(), nullable=True),
+        sa.Column('value_string', sa.String(), nullable=True),
+        sa.Column('create_ts', sa.DateTime(), nullable=False),
+        sa.Column('update_ts', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name'),
+    )
+
+    conn = op.get_bind()
+    session = Session(conn)
+    try:
+        root_group_id = session.execute(sa.text("SELECT \"id\" FROM \"group\" WHERE name = 'root'")).scalar()
+    except Exception:
+        pass
+
+    if root_group_id is None:
+        group: Group = Group.create(name="root", session=session)
+        for scope in session.execute(sa.text("SELECT * FROM \"scope\"")):
+            group.scopes.add(scope["id"])
+        root_group_id = group.id
+
+    try:
+        users_group_id = session.execute(sa.text("SELECT \"id\" FROM \"group\" WHERE name = 'users'")).scalar()
+    except Exception:
+        pass
+
+    if users_group_id is None:
+        group: Group = Group.create(name="users", session=session)
+        for user in session.execute(sa.text("SELECT * FROM \"user\"")):
+            group.users.append(user["id"])
+        users_group_id = group.id
+
+    session.flush()
+
+    values = [
+        {"name": "root_group_id", "create_ts": "now()", "update_ts": "now()", "value_integer": root_group_id},
+        {"name": "users_group_id", "create_ts": "now()", "update_ts": "now()", "value_integer": users_group_id},
+    ]
+    op.bulk_insert(dynamic_option_table, values)
+
+
+def downgrade():
+    op.drop_table('dynamic_option')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,9 @@ def group(dbsession, parent_id):
 
     yield _group
     for row in _ids:
-        Group.delete(row, session=dbsession)
+        group: Group = Group.get(row, session=dbsession)
+        group.users.clear()
+        group.delete(session=dbsession)
     dbsession.commit()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,8 @@ def yandex_user(dbsession) -> User:
     dbsession.add(user_id)
     dbsession.commit()
     yield user
+    user.sessions.clear()
+    user.groups.clear()
     dbsession.query(AuthMethod).filter(AuthMethod.user_id == user.id).delete()
     dbsession.query(User).filter(User.id == user.id).delete()
     dbsession.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def client_auth():
     patcher1.stop()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def dbsession():
     settings = get_settings()
     engine = create_engine(str(settings.DB_DSN))

--- a/tests/test_routes/test_groups.py
+++ b/tests/test_routes/test_groups.py
@@ -175,9 +175,6 @@ def test_delete(client, dbsession):
     assert db2 in db1.child
     assert db3 in db2.child
     assert db3.child == []
-    del db1
-    del db2
-    del db3
     response = client.get(f"/group/{_group3}")
     assert response.status_code == 200
     assert response.json()["parent_id"] == _group2
@@ -185,6 +182,9 @@ def test_delete(client, dbsession):
     assert response.status_code == 200
     assert response.json()["parent_id"] == _group1
     client.delete(f"/group/{_group2}")
+    dbsession.refresh(db1)
+    dbsession.refresh(db2)
+    dbsession.refresh(db3)
     response = client.get(f"/group/{_group3}")
     assert response.status_code == 200
     assert response.json()["parent_id"] == _group1
@@ -200,5 +200,6 @@ def test_delete(client, dbsession):
         dbsession.query(Group).get(_group2),
         dbsession.query(Group).get(_group3),
     ):
+        row: Group
         dbsession.delete(row)
     dbsession.commit()

--- a/tests/test_routes/test_groups.py
+++ b/tests/test_routes/test_groups.py
@@ -83,8 +83,10 @@ def test_get_all(client, dbsession):
     assert group in [row["id"] for row in response]
     assert child in [row["id"] for row in response]
     response = client.get("/group", params={"info": ["child"]}).json()["items"]
-    child_ = [row["child"] for row in response]
-    assert child in [row["id"] for row in child_[0]]
+    child_ = []
+    for row in response:
+        child_.extend(row["child"])
+    assert child in [row["id"] for row in child_]
 
     for row in (dbsession.query(Group).get(child), dbsession.query(Group).get(group)):
         dbsession.delete(row)


### PR DESCRIPTION
## Изменения
Делал автоматическое присваивание юзеров в группу users и автоматическое добавление скоупов группе root

## Детали реализации
- Во время миграции создается новая таблица с опциями. Опции бывают строковыми, даблавыми и интовыми
- Создаются 2 интовые опции: для группы root и для группы users, хранящие их id
- Если групп с такими именами еще не существует, создает группы и добавляет в них все существующие скоупы/юзеров соответственно