### PR TITLE
Auth method refactoring

### DIFF
--- a/auth_backend/auth_method/__init__.py
+++ b/auth_backend/auth_method/__init__.py
@@ -1,4 +1,4 @@
-from .base import AUTH_METHODS, AuthMethodMeta
+from .base import AUTH_METHODS, AuthPluginMeta
 from .method_mixins import LoginableMixin, RegistrableMixin
 from .oauth import OauthMeta
 from .session import Session
@@ -8,7 +8,7 @@ from .userdata_mixin import UserdataMixin
 __all__ = [
     "Session",
     "AUTH_METHODS",
-    "AuthMethodMeta",
+    "AuthPluginMeta",
     "OauthMeta",
     "LoginableMixin",
     "RegistrableMixin",

--- a/auth_backend/auth_method/__init__.py
+++ b/auth_backend/auth_method/__init__.py
@@ -1,4 +1,4 @@
-from .auth_method import AUTH_METHODS, AuthMethodMeta
+from .base import AUTH_METHODS, AuthMethodMeta
 from .oauth import OauthMeta
 from .session import Session
 

--- a/auth_backend/auth_method/__init__.py
+++ b/auth_backend/auth_method/__init__.py
@@ -1,6 +1,8 @@
 from .base import AUTH_METHODS, AuthMethodMeta
+from .method_mixins import LoginableMixin, RegistrableMixin
 from .oauth import OauthMeta
 from .session import Session
+from .userdata_mixin import UserdataMixin
 
 
 __all__ = [
@@ -8,4 +10,7 @@ __all__ = [
     "AUTH_METHODS",
     "AuthMethodMeta",
     "OauthMeta",
+    "LoginableMixin",
+    "RegistrableMixin",
+    "UserdataMixin",
 ]

--- a/auth_backend/auth_method/__init__.py
+++ b/auth_backend/auth_method/__init__.py
@@ -1,0 +1,11 @@
+from .auth_method import AUTH_METHODS, AuthMethodMeta
+from .oauth import OauthMeta
+from .session import Session
+
+
+__all__ = [
+    "Session",
+    "AUTH_METHODS",
+    "AuthMethodMeta",
+    "OauthMeta",
+]

--- a/auth_backend/auth_method/auth_method.py
+++ b/auth_backend/auth_method/auth_method.py
@@ -1,43 +1,24 @@
 from __future__ import annotations
 
 import logging
-import random
 import re
-import string
 from abc import ABCMeta, abstractmethod
 from asyncio import gather
-from datetime import datetime
-from typing import Annotated, Any, Iterable, final
+from typing import Any, Iterable, final
 
-from annotated_types import MinLen
 from event_schema.auth import UserLogin, UserLoginKey
-from fastapi import APIRouter, Depends
-from fastapi_sqlalchemy import db
+from fastapi import APIRouter
 from sqlalchemy.orm import Session as DbSession
 
-from auth_backend.base import Base
-from auth_backend.exceptions import LastAuthMethodDelete
-from auth_backend.models.db import AuthMethod, User, UserSession
+from auth_backend.auth_method.session import Session
+from auth_backend.models.db import User, UserSession
 from auth_backend.schemas.types.scopes import Scope as TypeScope
 from auth_backend.settings import get_settings
-from auth_backend.utils.security import UnionAuth
 from auth_backend.utils.user_session_control import create_session
 
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
-
-
-def random_string(length: int = 32) -> str:
-    return "".join([random.choice(string.ascii_letters) for _ in range(length)])
-
-
-class Session(Base):
-    token: Annotated[str, MinLen(1)]
-    expires: datetime
-    id: int
-    user_id: int
-    session_scopes: list[TypeScope]
 
 
 AUTH_METHODS: dict[str, type[AuthMethodMeta]] = {}
@@ -197,92 +178,3 @@ class AuthMethodMeta(metaclass=ABCMeta):
         for method in AUTH_METHODS.values():
             if method.is_active():
                 yield method
-
-
-class OauthMeta(AuthMethodMeta):
-    """Абстрактная авторизация и аутентификация через OAuth"""
-
-    class UrlSchema(Base):
-        url: str
-
-    def __init__(self):
-        super().__init__()
-        self.router.add_api_route("/redirect_url", self._redirect_url, methods=["GET"], response_model=self.UrlSchema)
-        self.router.add_api_route("/auth_url", self._auth_url, methods=["GET"], response_model=self.UrlSchema)
-        self.router.add_api_route("", self._unregister, methods=["DELETE"])
-
-    @staticmethod
-    @abstractmethod
-    async def _redirect_url(*args, **kwargs) -> UrlSchema:
-        """URL на который происходит редирект после завершения входа на стороне провайдера"""
-        raise NotImplementedError()
-
-    @staticmethod
-    @abstractmethod
-    async def _auth_url(*args, **kwargs) -> UrlSchema:
-        """URL на который происходит редирект из приложения для авторизации на стороне провайдера"""
-        raise NotImplementedError()
-
-    @classmethod
-    async def _unregister(cls, user_session: UserSession = Depends(UnionAuth(scopes=[], auto_error=True))):
-        """Отключает для пользователя метод входа"""
-        old_user = {"user_id": user_session.user.id}
-        new_user = {"user_id": user_session.user.id}
-        old_user_params = await cls._delete_auth_methods(user_session.user, db_session=db.session)
-        old_user[cls.get_name()] = old_user_params
-        await AuthMethodMeta.user_updated(new_user, old_user)
-        return None
-
-    @classmethod
-    async def _get_user(cls, key: str, value: str | int, *, db_session: DbSession) -> User | None:
-        auth_method: AuthMethod = (
-            AuthMethod.query(session=db_session)
-            .filter(
-                AuthMethod.param == key,
-                AuthMethod.value == str(value),
-                AuthMethod.auth_method == cls.get_name(),
-            )
-            .limit(1)
-            .one_or_none()
-        )
-        if auth_method:
-            return auth_method.user
-
-    @classmethod
-    async def _register_auth_method(cls, key: str, value: str | int, user: User, *, db_session) -> AuthMethod:
-        """Добавление пользователю новый AuthMethod"""
-        return AuthMethod.create(
-            user_id=user.id,
-            auth_method=cls.get_name(),
-            param=key,
-            value=str(value),
-            session=db_session,
-        )
-
-    @classmethod
-    async def _delete_auth_methods(cls, user: User, *, db_session) -> list[AuthMethod]:
-        """Удаляет пользователю все AuthMethod конкретной авторизации"""
-        auth_methods: list[AuthMethod] = (
-            AuthMethod.query(session=db_session)
-            .filter(
-                AuthMethod.user_id == user.id,
-                AuthMethod.auth_method == cls.get_name(),
-            )
-            .all()
-        )
-        all_auth_methods = AuthMethod.query(session=db_session).filter(AuthMethod.user_id == user.id).all()
-        if len(all_auth_methods) - len(auth_methods) == 0:
-            raise LastAuthMethodDelete()
-        logger.debug(auth_methods)
-        for method in auth_methods:
-            method.is_deleted = True
-        db_session.flush()
-        return {m.param: m.value for m in auth_methods}
-
-    @classmethod
-    def userdata_process_empty_strings(cls, userdata: UserLogin) -> UserLogin:
-        '''Изменяет значения с пустыми строками в параметре категории юзердаты на None'''
-        for item in userdata.items:
-            if item.value == '':
-                item.value = None
-        return userdata

--- a/auth_backend/auth_method/base.py
+++ b/auth_backend/auth_method/base.py
@@ -39,20 +39,10 @@ class AuthMethodMeta(metaclass=ABCMeta):
         self.router.add_api_route("/login", self._login, methods=["POST"], response_model=Session)
 
     def __init_subclass__(cls, **kwargs):
-        if cls.__name__.endswith('Meta'):
+        if cls.__name__.endswith('Meta') or cls.__name__.endswith('Mixin'):
             return
         logger.info(f'Init authmethod {cls.__name__}')
         AUTH_METHODS[cls.__name__] = cls
-
-    @staticmethod
-    @abstractmethod
-    async def _register(*args, **kwargs) -> object:
-        raise NotImplementedError()
-
-    @staticmethod
-    @abstractmethod
-    async def _login(*args, **kwargs) -> Session:
-        raise NotImplementedError()
 
     @staticmethod
     @final

--- a/auth_backend/auth_method/base.py
+++ b/auth_backend/auth_method/base.py
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 settings = get_settings()
 
 
-AUTH_METHODS: dict[str, type[AuthMethodMeta]] = {}
+AUTH_METHODS: dict[str, type[AuthPluginMeta]] = {}
 
 
-class AuthMethodMeta(metaclass=ABCMeta):
+class AuthPluginMeta(metaclass=ABCMeta):
     router: APIRouter
     prefix: str
     tags: list[str] = []
@@ -124,7 +124,7 @@ class AuthMethodMeta(metaclass=ABCMeta):
         ```
         """
         exceptions = await gather(
-            *[m.on_user_update(new_user, old_user) for m in AuthMethodMeta.active_auth_methods()],
+            *[m.on_user_update(new_user, old_user) for m in AuthPluginMeta.active_auth_methods()],
             return_exceptions=True,
         )
         if len(exceptions) > 0:
@@ -144,7 +144,7 @@ class AuthMethodMeta(metaclass=ABCMeta):
         return settings.ENABLED_AUTH_METHODS is None or cls.get_name() in settings.ENABLED_AUTH_METHODS
 
     @staticmethod
-    def active_auth_methods() -> Iterable[type['AuthMethodMeta']]:
+    def active_auth_methods() -> Iterable[type['AuthPluginMeta']]:
         for method in AUTH_METHODS.values():
             if method.is_active():
                 yield method

--- a/auth_backend/auth_method/base.py
+++ b/auth_backend/auth_method/base.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import logging
 import re
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from asyncio import gather
-from typing import Any, Iterable, final
+from typing import Any, Iterable
 
-from event_schema.auth import UserLogin, UserLoginKey
 from fastapi import APIRouter
 from sqlalchemy.orm import Session as DbSession
 
@@ -45,20 +44,6 @@ class AuthMethodMeta(metaclass=ABCMeta):
         AUTH_METHODS[cls.__name__] = cls
 
     @staticmethod
-    @final
-    def generate_kafka_key(user_id: int) -> UserLoginKey:
-        """
-        Мы генерируем ключи так как для сообщений с одинаковыми ключами
-        Kafka гарантирует последовательность чтений
-        Args:
-            user_id: Айди пользователя
-
-        Returns:
-            Ничего
-        """
-        return UserLoginKey.model_validate({"user_id": user_id})
-
-    @staticmethod
     async def _create_session(
         user: User, scopes_list_names: list[TypeScope] | None, session_name: str | None = None, *, db_session: DbSession
     ) -> Session:
@@ -94,11 +79,6 @@ class AuthMethodMeta(metaclass=ABCMeta):
         if user_session and (not user_session.expired or with_expired):
             return user_session.user
         return
-
-    @classmethod
-    @abstractmethod
-    async def _convert_data_to_userdata_format(cls, data: Any) -> UserLogin:
-        raise NotImplementedError()
 
     @staticmethod
     async def user_updated(

--- a/auth_backend/auth_method/method_mixins.py
+++ b/auth_backend/auth_method/method_mixins.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta, abstractmethod
 
-from .base import AuthMethodMeta
+from .base import AuthPluginMeta
 from .session import Session
 
 
-class RegistrableMixin(AuthMethodMeta, metaclass=ABCMeta):
+class RegistrableMixin(AuthPluginMeta, metaclass=ABCMeta):
     """Сообщает что AuthMethod поддерживает регистрацию
 
     Обязывает AuthMethod иметь метод `_register`, который используется как апи-запрос `/registration`
@@ -20,7 +20,7 @@ class RegistrableMixin(AuthMethodMeta, metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class LoginableMixin(AuthMethodMeta, metaclass=ABCMeta):
+class LoginableMixin(AuthPluginMeta, metaclass=ABCMeta):
     """Сообщает что AuthMethod поддерживает вход
 
     Обязывает AuthMethod иметь метод `_login`, который используется как апи-запрос `/login`

--- a/auth_backend/auth_method/method_mixins.py
+++ b/auth_backend/auth_method/method_mixins.py
@@ -1,0 +1,25 @@
+from abc import ABCMeta, abstractmethod
+from .base import AuthMethodMeta
+from .session import Session
+
+
+class RegistrableMixin(AuthMethodMeta, metaclass=ABCMeta):
+    def __init__(self):
+        super().__init__()
+        self.router.add_api_route("/registration", self._register, methods=["POST"])
+
+    @staticmethod
+    @abstractmethod
+    async def _register(*args, **kwargs) -> object:
+        raise NotImplementedError()
+
+
+class LoginableMixin(AuthMethodMeta, metaclass=ABCMeta):
+    def __init__(self):
+        super().__init__()
+        self.router.add_api_route("/login", self._login, methods=["POST"], response_model=Session)
+
+    @staticmethod
+    @abstractmethod
+    async def _login(*args, **kwargs) -> Session:
+        raise NotImplementedError()

--- a/auth_backend/auth_method/method_mixins.py
+++ b/auth_backend/auth_method/method_mixins.py
@@ -1,9 +1,15 @@
 from abc import ABCMeta, abstractmethod
+
 from .base import AuthMethodMeta
 from .session import Session
 
 
 class RegistrableMixin(AuthMethodMeta, metaclass=ABCMeta):
+    """Сообщает что AuthMethod поддерживает регистрацию
+
+    Обязывает AuthMethod иметь метод `_register`, который используется как апи-запрос `/registration`
+    """
+
     def __init__(self):
         super().__init__()
         self.router.add_api_route("/registration", self._register, methods=["POST"])
@@ -15,6 +21,11 @@ class RegistrableMixin(AuthMethodMeta, metaclass=ABCMeta):
 
 
 class LoginableMixin(AuthMethodMeta, metaclass=ABCMeta):
+    """Сообщает что AuthMethod поддерживает вход
+
+    Обязывает AuthMethod иметь метод `_login`, который используется как апи-запрос `/login`
+    """
+
     def __init__(self):
         super().__init__()
         self.router.add_api_route("/login", self._login, methods=["POST"], response_model=Session)

--- a/auth_backend/auth_method/oauth.py
+++ b/auth_backend/auth_method/oauth.py
@@ -10,7 +10,7 @@ from auth_backend.exceptions import LastAuthMethodDelete
 from auth_backend.models.db import AuthMethod, User, UserSession
 from auth_backend.utils.security import UnionAuth
 
-from .base import AuthMethodMeta
+from .base import AuthPluginMeta
 from .method_mixins import LoginableMixin, RegistrableMixin
 from .userdata_mixin import UserdataMixin
 
@@ -18,7 +18,7 @@ from .userdata_mixin import UserdataMixin
 logger = logging.getLogger(__name__)
 
 
-class OauthMeta(UserdataMixin, LoginableMixin, RegistrableMixin, AuthMethodMeta):
+class OauthMeta(UserdataMixin, LoginableMixin, RegistrableMixin, AuthPluginMeta):
     """Абстрактная авторизация и аутентификация через OAuth"""
 
     class UrlSchema(Base):
@@ -49,7 +49,7 @@ class OauthMeta(UserdataMixin, LoginableMixin, RegistrableMixin, AuthMethodMeta)
         new_user = {"user_id": user_session.user.id}
         old_user_params = await cls._delete_auth_methods(user_session.user, db_session=db.session)
         old_user[cls.get_name()] = old_user_params
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return None
 
     @classmethod

--- a/auth_backend/auth_method/oauth.py
+++ b/auth_backend/auth_method/oauth.py
@@ -1,18 +1,24 @@
 from abc import abstractmethod
+import logging
 
 from event_schema.auth import UserLogin
 from fastapi import Depends
 from fastapi_sqlalchemy import db
 from sqlalchemy.orm import Session as DbSession
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta, logger
 from auth_backend.base import Base
 from auth_backend.exceptions import LastAuthMethodDelete
 from auth_backend.models.db import AuthMethod, User, UserSession
 from auth_backend.utils.security import UnionAuth
 
+from .base import AuthMethodMeta
+from .method_mixins import LoginableMixin, RegistrableMixin
 
-class OauthMeta(AuthMethodMeta):
+
+logger = logging.getLogger(__name__)
+
+
+class OauthMeta(LoginableMixin, RegistrableMixin, AuthMethodMeta):
     """Абстрактная авторизация и аутентификация через OAuth"""
 
     class UrlSchema(Base):

--- a/auth_backend/auth_method/oauth.py
+++ b/auth_backend/auth_method/oauth.py
@@ -1,7 +1,6 @@
-from abc import abstractmethod
 import logging
+from abc import abstractmethod
 
-from event_schema.auth import UserLogin
 from fastapi import Depends
 from fastapi_sqlalchemy import db
 from sqlalchemy.orm import Session as DbSession
@@ -13,12 +12,13 @@ from auth_backend.utils.security import UnionAuth
 
 from .base import AuthMethodMeta
 from .method_mixins import LoginableMixin, RegistrableMixin
+from .userdata_mixin import UserdataMixin
 
 
 logger = logging.getLogger(__name__)
 
 
-class OauthMeta(LoginableMixin, RegistrableMixin, AuthMethodMeta):
+class OauthMeta(UserdataMixin, LoginableMixin, RegistrableMixin, AuthMethodMeta):
     """Абстрактная авторизация и аутентификация через OAuth"""
 
     class UrlSchema(Base):
@@ -97,11 +97,3 @@ class OauthMeta(LoginableMixin, RegistrableMixin, AuthMethodMeta):
             method.is_deleted = True
         db_session.flush()
         return {m.param: m.value for m in auth_methods}
-
-    @classmethod
-    def userdata_process_empty_strings(cls, userdata: UserLogin) -> UserLogin:
-        '''Изменяет значения с пустыми строками в параметре категории юзердаты на None'''
-        for item in userdata.items:
-            if item.value == '':
-                item.value = None
-        return userdata

--- a/auth_backend/auth_method/oauth.py
+++ b/auth_backend/auth_method/oauth.py
@@ -1,0 +1,101 @@
+from abc import abstractmethod
+
+from event_schema.auth import UserLogin
+from fastapi import Depends
+from fastapi_sqlalchemy import db
+from sqlalchemy.orm import Session as DbSession
+
+from auth_backend.auth_method.auth_method import AuthMethodMeta, logger
+from auth_backend.base import Base
+from auth_backend.exceptions import LastAuthMethodDelete
+from auth_backend.models.db import AuthMethod, User, UserSession
+from auth_backend.utils.security import UnionAuth
+
+
+class OauthMeta(AuthMethodMeta):
+    """Абстрактная авторизация и аутентификация через OAuth"""
+
+    class UrlSchema(Base):
+        url: str
+
+    def __init__(self):
+        super().__init__()
+        self.router.add_api_route("/redirect_url", self._redirect_url, methods=["GET"], response_model=self.UrlSchema)
+        self.router.add_api_route("/auth_url", self._auth_url, methods=["GET"], response_model=self.UrlSchema)
+        self.router.add_api_route("", self._unregister, methods=["DELETE"])
+
+    @staticmethod
+    @abstractmethod
+    async def _redirect_url(*args, **kwargs) -> UrlSchema:
+        """URL на который происходит редирект после завершения входа на стороне провайдера"""
+        raise NotImplementedError()
+
+    @staticmethod
+    @abstractmethod
+    async def _auth_url(*args, **kwargs) -> UrlSchema:
+        """URL на который происходит редирект из приложения для авторизации на стороне провайдера"""
+        raise NotImplementedError()
+
+    @classmethod
+    async def _unregister(cls, user_session: UserSession = Depends(UnionAuth(scopes=[], auto_error=True))):
+        """Отключает для пользователя метод входа"""
+        old_user = {"user_id": user_session.user.id}
+        new_user = {"user_id": user_session.user.id}
+        old_user_params = await cls._delete_auth_methods(user_session.user, db_session=db.session)
+        old_user[cls.get_name()] = old_user_params
+        await AuthMethodMeta.user_updated(new_user, old_user)
+        return None
+
+    @classmethod
+    async def _get_user(cls, key: str, value: str | int, *, db_session: DbSession) -> User | None:
+        auth_method: AuthMethod = (
+            AuthMethod.query(session=db_session)
+            .filter(
+                AuthMethod.param == key,
+                AuthMethod.value == str(value),
+                AuthMethod.auth_method == cls.get_name(),
+            )
+            .limit(1)
+            .one_or_none()
+        )
+        if auth_method:
+            return auth_method.user
+
+    @classmethod
+    async def _register_auth_method(cls, key: str, value: str | int, user: User, *, db_session) -> AuthMethod:
+        """Добавление пользователю новый AuthMethod"""
+        return AuthMethod.create(
+            user_id=user.id,
+            auth_method=cls.get_name(),
+            param=key,
+            value=str(value),
+            session=db_session,
+        )
+
+    @classmethod
+    async def _delete_auth_methods(cls, user: User, *, db_session) -> list[AuthMethod]:
+        """Удаляет пользователю все AuthMethod конкретной авторизации"""
+        auth_methods: list[AuthMethod] = (
+            AuthMethod.query(session=db_session)
+            .filter(
+                AuthMethod.user_id == user.id,
+                AuthMethod.auth_method == cls.get_name(),
+            )
+            .all()
+        )
+        all_auth_methods = AuthMethod.query(session=db_session).filter(AuthMethod.user_id == user.id).all()
+        if len(all_auth_methods) - len(auth_methods) == 0:
+            raise LastAuthMethodDelete()
+        logger.debug(auth_methods)
+        for method in auth_methods:
+            method.is_deleted = True
+        db_session.flush()
+        return {m.param: m.value for m in auth_methods}
+
+    @classmethod
+    def userdata_process_empty_strings(cls, userdata: UserLogin) -> UserLogin:
+        '''Изменяет значения с пустыми строками в параметре категории юзердаты на None'''
+        for item in userdata.items:
+            if item.value == '':
+                item.value = None
+        return userdata

--- a/auth_backend/auth_method/session.py
+++ b/auth_backend/auth_method/session.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from typing import Annotated
+
+from annotated_types import MinLen
+
+from auth_backend.base import Base
+from auth_backend.schemas.types.scopes import Scope as TypeScope
+
+
+class Session(Base):
+    token: Annotated[str, MinLen(1)]
+    expires: datetime
+    id: int
+    user_id: int
+    session_scopes: list[TypeScope]

--- a/auth_backend/auth_method/userdata_mixin.py
+++ b/auth_backend/auth_method/userdata_mixin.py
@@ -3,10 +3,10 @@ from typing import Any, final
 
 from event_schema.auth import UserLogin, UserLoginKey
 
-from .base import AuthMethodMeta
+from .base import AuthPluginMeta
 
 
-class UserdataMixin(AuthMethodMeta, metaclass=ABCMeta):
+class UserdataMixin(AuthPluginMeta, metaclass=ABCMeta):
     """Включает поддержку отправки данных о пользователе в сервис Userdata API
 
     Подробнее о Userdata API: https://github.com/profcomff/userdata-api

--- a/auth_backend/auth_method/userdata_mixin.py
+++ b/auth_backend/auth_method/userdata_mixin.py
@@ -1,0 +1,40 @@
+from abc import ABCMeta, abstractmethod
+from typing import Any, final
+
+from event_schema.auth import UserLogin, UserLoginKey
+
+from .base import AuthMethodMeta
+
+
+class UserdataMixin(AuthMethodMeta, metaclass=ABCMeta):
+    """Включает поддержку отправки данных о пользователе в сервис Userdata API
+
+    Подробнее о Userdata API: https://github.com/profcomff/userdata-api
+    """
+
+    @staticmethod
+    @final
+    def generate_kafka_key(user_id: int) -> UserLoginKey:
+        """
+        Мы генерируем ключи так как для сообщений с одинаковыми ключами
+        Kafka гарантирует последовательность чтений
+        Args:
+            user_id: Айди пользователя
+
+        Returns:
+            Ничего
+        """
+        return UserLoginKey.model_validate({"user_id": user_id})
+
+    @classmethod
+    @abstractmethod
+    async def _convert_data_to_userdata_format(cls, data: Any) -> UserLogin:
+        raise NotImplementedError()
+
+    @classmethod
+    def userdata_process_empty_strings(cls, userdata: UserLogin) -> UserLogin:
+        """Изменяет значения с пустыми строками в параметре категории юзердаты на None"""
+        for item in userdata.items:
+            if item.value == '':
+                item.value = None
+        return userdata

--- a/auth_backend/auth_plugins/__init__.py
+++ b/auth_backend/auth_plugins/__init__.py
@@ -1,4 +1,5 @@
-from .auth_method import AUTH_METHODS, AuthMethodMeta
+from auth_backend.auth_method.auth_method import AUTH_METHODS, AuthMethodMeta
+
 from .email import Email
 from .github import GithubAuth
 from .google import GoogleAuth

--- a/auth_backend/auth_plugins/__init__.py
+++ b/auth_backend/auth_plugins/__init__.py
@@ -1,4 +1,4 @@
-from auth_backend.auth_method import AUTH_METHODS, AuthMethodMeta
+from auth_backend.auth_method import AUTH_METHODS, AuthPluginMeta
 
 from .email import Email
 from .github import GithubAuth
@@ -14,7 +14,7 @@ from .yandex import YandexAuth
 
 __all__ = [
     "AUTH_METHODS",
-    "AuthMethodMeta",
+    "AuthPluginMeta",
     "Email",
     "GoogleAuth",
     "PhysicsAuth",

--- a/auth_backend/auth_plugins/__init__.py
+++ b/auth_backend/auth_plugins/__init__.py
@@ -1,4 +1,4 @@
-from auth_backend.auth_method.auth_method import AUTH_METHODS, AuthMethodMeta
+from auth_backend.auth_method import AUTH_METHODS, AuthMethodMeta
 
 from .email import Email
 from .github import GithubAuth

--- a/auth_backend/auth_plugins/email.py
+++ b/auth_backend/auth_plugins/email.py
@@ -10,8 +10,9 @@ from fastapi_sqlalchemy import db
 from pydantic import field_validator, model_validator
 from sqlalchemy import func
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import Session
+from auth_backend.auth_method.method_mixins import LoginableMixin, RegistrableMixin
 from auth_backend.base import Base, StatusResponseModel
 from auth_backend.exceptions import AlreadyExists, AuthFailed, IncorrectUserAuthType, SessionExpired
 from auth_backend.kafka.kafka import get_kafka_producer
@@ -104,7 +105,7 @@ class ResetForgottenPassword(Base):
     new_password: Annotated[str, MinLen(1)]
 
 
-class Email(AuthMethodMeta):
+class Email(LoginableMixin, RegistrableMixin, AuthMethodMeta):
     prefix = "/email"
 
     @staticmethod

--- a/auth_backend/auth_plugins/email.py
+++ b/auth_backend/auth_plugins/email.py
@@ -10,9 +10,7 @@ from fastapi_sqlalchemy import db
 from pydantic import field_validator, model_validator
 from sqlalchemy import func
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import Session
-from auth_backend.auth_method.method_mixins import LoginableMixin, RegistrableMixin
+from auth_backend.auth_method import AuthMethodMeta, LoginableMixin, RegistrableMixin, Session, UserdataMixin
 from auth_backend.base import Base, StatusResponseModel
 from auth_backend.exceptions import AlreadyExists, AuthFailed, IncorrectUserAuthType, SessionExpired
 from auth_backend.kafka.kafka import get_kafka_producer
@@ -105,7 +103,7 @@ class ResetForgottenPassword(Base):
     new_password: Annotated[str, MinLen(1)]
 
 
-class Email(LoginableMixin, RegistrableMixin, AuthMethodMeta):
+class Email(UserdataMixin, LoginableMixin, RegistrableMixin, AuthMethodMeta):
     prefix = "/email"
 
     @staticmethod

--- a/auth_backend/auth_plugins/email.py
+++ b/auth_backend/auth_plugins/email.py
@@ -10,6 +10,8 @@ from fastapi_sqlalchemy import db
 from pydantic import field_validator, model_validator
 from sqlalchemy import func
 
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.base import Base, StatusResponseModel
 from auth_backend.exceptions import AlreadyExists, AuthFailed, IncorrectUserAuthType, SessionExpired
 from auth_backend.kafka.kafka import get_kafka_producer
@@ -19,8 +21,7 @@ from auth_backend.settings import get_settings
 from auth_backend.utils.auth_params import get_auth_params
 from auth_backend.utils.security import UnionAuth
 from auth_backend.utils.smtp import SendEmailMessage
-
-from .auth_method import AuthMethodMeta, Session, random_string
+from auth_backend.utils.string import random_string
 
 
 settings = get_settings()

--- a/auth_backend/auth_plugins/github.py
+++ b/auth_backend/auth_plugins/github.py
@@ -10,14 +10,15 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
 from auth_backend.schemas.types.scopes import Scope
 from auth_backend.settings import Settings
 from auth_backend.utils.security import UnionAuth
-
-from .auth_method import AuthMethodMeta, OauthMeta, Session
 
 
 logger = logging.getLogger(__name__)

--- a/auth_backend/auth_plugins/github.py
+++ b/auth_backend/auth_plugins/github.py
@@ -10,9 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/github.py
+++ b/auth_backend/auth_plugins/github.py
@@ -10,9 +10,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/github.py
+++ b/auth_backend/auth_plugins/github.py
@@ -10,7 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -112,7 +112,7 @@ class GithubAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/google.py
+++ b/auth_backend/auth_plugins/google.py
@@ -12,7 +12,7 @@ from google.auth.transport import requests
 from google.oauth2.id_token import verify_oauth2_token
 from pydantic import BaseModel, Field, Json
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed, OauthCredentialsIncorrect
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -120,7 +120,7 @@ class GoogleAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/google.py
+++ b/auth_backend/auth_plugins/google.py
@@ -12,9 +12,7 @@ from google.auth.transport import requests
 from google.oauth2.id_token import verify_oauth2_token
 from pydantic import BaseModel, Field, Json
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed, OauthCredentialsIncorrect
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/google.py
+++ b/auth_backend/auth_plugins/google.py
@@ -12,9 +12,9 @@ from google.auth.transport import requests
 from google.oauth2.id_token import verify_oauth2_token
 from pydantic import BaseModel, Field, Json
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed, OauthCredentialsIncorrect
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/google.py
+++ b/auth_backend/auth_plugins/google.py
@@ -12,14 +12,15 @@ from google.auth.transport import requests
 from google.oauth2.id_token import verify_oauth2_token
 from pydantic import BaseModel, Field, Json
 
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed, OauthCredentialsIncorrect
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
 from auth_backend.schemas.types.scopes import Scope
 from auth_backend.settings import Settings
 from auth_backend.utils.security import UnionAuth
-
-from .auth_method import AuthMethodMeta, OauthMeta, Session
 
 
 logger = logging.getLogger(__name__)

--- a/auth_backend/auth_plugins/keycloak.py
+++ b/auth_backend/auth_plugins/keycloak.py
@@ -10,14 +10,15 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
 from auth_backend.schemas.types.scopes import Scope
 from auth_backend.settings import Settings
 from auth_backend.utils.security import UnionAuth
-
-from .auth_method import AuthMethodMeta, OauthMeta, Session
 
 
 logger = logging.getLogger(__name__)

--- a/auth_backend/auth_plugins/keycloak.py
+++ b/auth_backend/auth_plugins/keycloak.py
@@ -10,9 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/keycloak.py
+++ b/auth_backend/auth_plugins/keycloak.py
@@ -10,7 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -108,7 +108,7 @@ class KeycloakAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/keycloak.py
+++ b/auth_backend/auth_plugins/keycloak.py
@@ -10,9 +10,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/lkmsu.py
+++ b/auth_backend/auth_plugins/lkmsu.py
@@ -10,6 +10,9 @@ from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTasks
 
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -17,8 +20,6 @@ from auth_backend.schemas.types.scopes import Scope
 from auth_backend.settings import Settings
 from auth_backend.utils.security import UnionAuth
 from auth_backend.utils.string import concantenate_strings
-
-from .auth_method import AuthMethodMeta, OauthMeta, Session
 
 
 logger = logging.getLogger(__name__)

--- a/auth_backend/auth_plugins/lkmsu.py
+++ b/auth_backend/auth_plugins/lkmsu.py
@@ -10,9 +10,9 @@ from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTasks
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/lkmsu.py
+++ b/auth_backend/auth_plugins/lkmsu.py
@@ -10,9 +10,7 @@ from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTasks
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/lkmsu.py
+++ b/auth_backend/auth_plugins/lkmsu.py
@@ -10,7 +10,7 @@ from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTasks
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -107,7 +107,7 @@ class LkmsuAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/telegram.py
+++ b/auth_backend/auth_plugins/telegram.py
@@ -11,9 +11,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/telegram.py
+++ b/auth_backend/auth_plugins/telegram.py
@@ -11,9 +11,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/telegram.py
+++ b/auth_backend/auth_plugins/telegram.py
@@ -11,7 +11,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_plugins.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/telegram.py
+++ b/auth_backend/auth_plugins/telegram.py
@@ -11,7 +11,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -86,7 +86,7 @@ class TelegramAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/vk.py
+++ b/auth_backend/auth_plugins/vk.py
@@ -10,9 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/vk.py
+++ b/auth_backend/auth_plugins/vk.py
@@ -10,7 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -119,7 +119,7 @@ class VkAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/vk.py
+++ b/auth_backend/auth_plugins/vk.py
@@ -10,9 +10,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/vk.py
+++ b/auth_backend/auth_plugins/vk.py
@@ -10,6 +10,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -18,7 +21,6 @@ from auth_backend.utils.security import UnionAuth
 from auth_backend.utils.string import concantenate_strings
 
 from ..schemas.types.scopes import Scope
-from .auth_method import AuthMethodMeta, OauthMeta, Session
 
 
 logger = logging.getLogger(__name__)

--- a/auth_backend/auth_plugins/yandex.py
+++ b/auth_backend/auth_plugins/yandex.py
@@ -10,9 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta
-from auth_backend.auth_method import OauthMeta
-from auth_backend.auth_method import Session
+from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/yandex.py
+++ b/auth_backend/auth_plugins/yandex.py
@@ -10,9 +10,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
-from auth_backend.auth_method.oauth import OauthMeta
-from auth_backend.auth_method.session import Session
+from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import OauthMeta
+from auth_backend.auth_method import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/auth_plugins/yandex.py
+++ b/auth_backend/auth_plugins/yandex.py
@@ -10,7 +10,7 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method import AuthPluginMeta, OauthMeta, Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession
@@ -124,7 +124,7 @@ class YandexAuth(OauthMeta):
             userdata,
             bg_tasks=background_tasks,
         )
-        await AuthMethodMeta.user_updated(new_user, old_user)
+        await AuthPluginMeta.user_updated(new_user, old_user)
         return await cls._create_session(
             user, user_inp.scopes, db_session=db.session, session_name=user_inp.session_name
         )

--- a/auth_backend/auth_plugins/yandex.py
+++ b/auth_backend/auth_plugins/yandex.py
@@ -10,7 +10,9 @@ from fastapi.background import BackgroundTasks
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, Field
 
-from auth_backend.auth_plugins.auth_method import AuthMethodMeta, OauthMeta, Session
+from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method.oauth import OauthMeta
+from auth_backend.auth_method.session import Session
 from auth_backend.exceptions import AlreadyExists, OauthAuthFailed
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.models.db import User, UserSession

--- a/auth_backend/cli/user.py
+++ b/auth_backend/cli/user.py
@@ -3,8 +3,8 @@ import errno
 from sqlalchemy.orm import Session
 
 from auth_backend.auth_plugins import Email
-from auth_backend.auth_plugins.auth_method import random_string
 from auth_backend.models import AuthMethod, User
+from auth_backend.utils.string import random_string
 
 
 def create_user(email: str, password: str, session: Session) -> None:

--- a/auth_backend/routes/base.py
+++ b/auth_backend/routes/base.py
@@ -5,7 +5,7 @@ from fastapi_sqlalchemy import DBSessionMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 from auth_backend import __version__
-from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import AuthPluginMeta
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.settings import get_settings
 
@@ -55,5 +55,5 @@ app.include_router(groups)
 app.include_router(scopes)
 app.include_router(user)
 
-for method in AuthMethodMeta.active_auth_methods():
+for method in AuthPluginMeta.active_auth_methods():
     app.include_router(router=method().router, prefix=method.prefix, tags=[method.get_name()])

--- a/auth_backend/routes/base.py
+++ b/auth_backend/routes/base.py
@@ -5,7 +5,7 @@ from fastapi_sqlalchemy import DBSessionMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 from auth_backend import __version__
-from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method import AuthMethodMeta
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.settings import get_settings
 

--- a/auth_backend/routes/base.py
+++ b/auth_backend/routes/base.py
@@ -5,7 +5,7 @@ from fastapi_sqlalchemy import DBSessionMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 from auth_backend import __version__
-from auth_backend.auth_plugins.auth_method import AuthMethodMeta
+from auth_backend.auth_method.auth_method import AuthMethodMeta
 from auth_backend.kafka.kafka import get_kafka_producer
 from auth_backend.settings import get_settings
 

--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi_sqlalchemy import db
 from sqlalchemy.orm import Session
 
-from auth_backend.auth_plugins.auth_method import AuthMethodMeta
+from auth_backend.auth_method.auth_method import AuthMethodMeta
 from auth_backend.models.db import AuthMethod, Group, User, UserGroup, UserSession
 from auth_backend.schemas.models import User as UserModel
 from auth_backend.schemas.models import (

--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi_sqlalchemy import db
 from sqlalchemy.orm import Session
 
-from auth_backend.auth_method import AuthMethodMeta
+from auth_backend.auth_method import AuthPluginMeta
 from auth_backend.models.db import AuthMethod, Group, User, UserGroup, UserSession
 from auth_backend.schemas.models import User as UserModel
 from auth_backend.schemas.models import (
@@ -162,5 +162,5 @@ async def delete_user(
         logger.info(f'{method=} for {user.id=} deleted')
 
     User.delete(user_id, session=db.session)
-    await AuthMethodMeta.user_updated(None, old_user)
+    await AuthPluginMeta.user_updated(None, old_user)
     logger.info(f'{user=} deleted')

--- a/auth_backend/routes/user.py
+++ b/auth_backend/routes/user.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi_sqlalchemy import db
 from sqlalchemy.orm import Session
 
-from auth_backend.auth_method.auth_method import AuthMethodMeta
+from auth_backend.auth_method import AuthMethodMeta
 from auth_backend.models.db import AuthMethod, Group, User, UserGroup, UserSession
 from auth_backend.schemas.models import User as UserModel
 from auth_backend.schemas.models import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,11 @@ from sqlalchemy.orm import sessionmaker
 from starlette import status
 
 from auth_backend.auth_plugins import YandexAuth
-from auth_backend.auth_plugins.auth_method import random_string
 from auth_backend.models import AuthMethod, User
 from auth_backend.models.db import AuthMethod, Group, GroupScope, Scope, User, UserGroup, UserSession, UserSessionScope
 from auth_backend.routes.base import app
 from auth_backend.settings import get_settings
+from auth_backend.utils.string import random_string
 
 
 @pytest.fixture

--- a/tests/test_routes/test_scopes.py
+++ b/tests/test_routes/test_scopes.py
@@ -2,8 +2,8 @@ from fastapi.testclient import TestClient
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from auth_backend.auth_plugins.auth_method import random_string
 from auth_backend.models.db import Scope, UserSession
+from auth_backend.utils.string import random_string
 
 
 def test_create_scope(client_auth: TestClient, dbsession: Session, user_scopes):

--- a/tests/test_update_user.py
+++ b/tests/test_update_user.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from auth_backend.auth_plugins.auth_method import AUTH_METHODS, AuthMethodMeta
+from auth_backend.auth_method.auth_method import AUTH_METHODS, AuthMethodMeta
 
 
 if TYPE_CHECKING:

--- a/tests/test_update_user.py
+++ b/tests/test_update_user.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from auth_backend.auth_method.auth_method import AUTH_METHODS, AuthMethodMeta
+from auth_backend.auth_method import AUTH_METHODS, AuthMethodMeta
 
 
 if TYPE_CHECKING:

--- a/tests/test_update_user.py
+++ b/tests/test_update_user.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from auth_backend.auth_method import AUTH_METHODS, AuthMethodMeta
+from auth_backend.auth_method import AUTH_METHODS, AuthPluginMeta
 
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ async def test_user_updated():
         patches[auth_method] = patch(f"auth_backend.auth_plugins.{auth_method}.on_user_update")
         mocks[auth_method] = patches[auth_method].start()
 
-    await AuthMethodMeta.user_updated({"user_id": 123})
+    await AuthPluginMeta.user_updated({"user_id": 123})
 
     for auth_method in patches:
         if AUTH_METHODS[auth_method].is_active():


### PR DESCRIPTION
## Изменения
Метаклассы AuthMethod перенесены в отдельную папку  и разделены на несколько

## Детали реализации
Теперь `AuthPluginMeta` (ex. `AuthMethodMeta`) – это абстрактный класс минимального плагина аутентификации. Дополнительная функциональность подключается миксинами:
- `LoginMixin` – требуется для ручки `/login`
- `RegisterMixin` – требуется для ручки `/register`
- `UserdataMixin` – требуется для работы с кафкой и отправки событий в Userdata API

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
