### PR TITLE
Fix double email reg issue

### DIFF
--- a/auth_backend/auth_plugins/email.py
+++ b/auth_backend/auth_plugins/email.py
@@ -229,6 +229,13 @@ class Email(UserdataMixin, LoginableMixin, RegistrableMixin, AuthPluginMeta):
                 user = await cls._get_user(user_session=user_session, db_session=txn)
                 if not user:
                     raise SessionExpired(user_session.token)
+                auth_method: AuthMethod | None = (
+                    AuthMethod.query(session=txn)
+                    .filter(AuthMethod.auth_method == Email.get_name(), AuthMethod.user_id == user.id)
+                    .first()
+                )
+                if auth_method:
+                    raise AlreadyExists(User, user.id)
             else:
                 user = await cls._create_user(db_session=txn)
             method_params = await Email._add_to_db(user_inp, confirmation_token, user)


### PR DESCRIPTION
## Изменения
Запрет на привязку почты (Email) к аккаунту у которого уже есть привязанная почта (Email)

## Детали реализации
При попытке привязать почту к аккаунту юзера повторно (post email/registration с токеном сессии юзера ) вернётся код 409 Already exists (Поведение одинаковое, как для почты идентичной привязанной, так и для абсолютно новой почты) 

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
